### PR TITLE
Add note "hit GTC target" to closed double dip trade

### DIFF
--- a/parse/journal.go
+++ b/parse/journal.go
@@ -261,6 +261,8 @@ func (j *Journal) ReadTransactions(csvPath string) []Transaction {
 
 						costBasisPerShare := costBasisTotal / shares
 						singleTransaction.costBasisShare = fmt.Sprint(costBasisPerShare)
+						singleTransaction.notes = "hit GTC target"
+						transaction.notes = "hit GTC target"
 
 						j.updateSingleTransaction(transaction.ticker, *singleTransaction)
 					}

--- a/parse/journal_test.go
+++ b/parse/journal_test.go
@@ -152,6 +152,7 @@ func TestReadTransactions(t *testing.T) {
 			costBasisTotal:       "3817",       // imports IBKR value and multiply by -1
 			realizedPL:           "326.482091", // imports IBKR value
 			commission:           "-0.51790925",
+			notes:                "hit GTC target",
 		},
 		{
 			date:                 "2023-06-08",
@@ -166,6 +167,7 @@ func TestReadTransactions(t *testing.T) {
 			costBasisShare:       "0",
 			costBasisBuyOrOption: "-654.05155",
 			commission:           "-1.05155",
+			notes:                "hit GTC target",
 		},
 	}
 


### PR DESCRIPTION
add automated notes that GTC target was hit whenever a double dip trade is close (buy back call, sell stock)